### PR TITLE
use helm-exit-and-execute-action

### DIFF
--- a/helm-hayoo.el
+++ b/helm-hayoo.el
@@ -183,13 +183,13 @@
   "Execute import action from `helm-source-hayoo'."
   (interactive)
   (with-helm-alive-p
-    (helm-quit-and-execute-action 'helm-hayoo-action-import)))
+    (helm-exit-and-execute-action 'helm-hayoo-action-import)))
 
 (defun helm-hayoo-run-browse-haddock ()
   "Execute browse haddock action from `helm-source-hayoo'."
   (interactive)
   (with-helm-alive-p
-    (helm-quit-and-execute-action 'helm-hayoo-action-browse-haddock)))
+    (helm-exit-and-execute-action 'helm-hayoo-action-browse-haddock)))
 
 (defvar helm-hayoo-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
`helm-quit-and-execute-action` is obsolete and causes compiler warnings:

```
In helm-hayoo-run-import-this:
helm-hayoo.el:184:4:Warning: `helm-quit-and-execute-action' is an obsolete
    function (as of 1.7.7); use `helm-exit-and-execute-action' instead.

In helm-hayoo-run-browse-haddock:
helm-hayoo.el:190:4:Warning: `helm-quit-and-execute-action' is an obsolete
    function (as of 1.7.7); use `helm-exit-and-execute-action' instead.
```
